### PR TITLE
大佬，发现您的项目引入了com.google.guava:guava@17.0组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.t0ugh</groupId>
@@ -20,7 +18,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <netty.version>4.1.49.Final</netty.version>
         <protobuf.version>3.6.1</protobuf.version>
-        <guava.version>17.0</guava.version>
+        <guava.version>30.0-android</guava.version>
         <junit.version>4.11</junit.version>
         <lombok.version>1.18.12</lombok.version>
         <slf4j.version>1.7.25</slf4j.version>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Google Guava无限内存分配漏洞
缺陷组件：com.google.guava:guava@17.0
漏洞编号：CVE-2018-10237
漏洞描述：Google Guava是美国谷歌（Google）公司开发的一款包括图形库、函数类型、I/O和字符串处理等的Java核心库。

Google Guava 11.0版本至24.1.1版本（不包括24.1.1版本）中存在安全漏洞，该漏洞源于程序未能正确的检测客户端发送的内容及数据大小是否合理。远程攻击者可利用该漏洞造成拒绝服务。
国家漏洞库信息：https://www.cnvd.org.cn/flaw/show/CNVD-2018-10064
影响范围：[11.0, 24.1.1-android)
最小修复版本：30.0-android
缺陷组件引入路径：com.t0ugh:toycache-server@1.0-SNAPSHOT->com.google.guava:guava@17.0
```
另外我运行这个项目时，IDE的安全插件提示还有11个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=pcccb6